### PR TITLE
TECH-12624 Allow config options to Percona

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.5] - 10-08-2020
+- Allow passing config options to percona_alter_table as a hash
+- Add documentation for config options
+- Create changelog
+
+## [0.0.4] - 18-03-2016
+- Create lib/percona-migrations-livelink.rb
+
+## [0.0.3] - 17-03-2016
+- Fork project from original repo
+- Add support for most pt-online-schema-change config options
+- Set up travis-ci
+
+## [0.0.2] - 12-02-2015
+- Add link to homepage
+
+## [0.0.1] - 12-02-2015
+- First official release tag

--- a/README.md
+++ b/README.md
@@ -48,6 +48,30 @@ class AddAddressToUsers < ActiveRecord::Migration
 end
 ```
 
+## Configuration
+
+Additional config can optionally be passed either in the initializer or in the migration itself
+
+### As a block in the initializer
+
+```ruby
+PerconaMigrations.config do |c|
+  c.drop_old_table = false
+  c.max_load       = 'Threads_running=60'
+end
+```
+
+### As a hash argument to the `percona_alter_table` command
+
+```ruby
+def up
+  commands = columns.map { |name, type| "ADD COLUMN #{name} #{type}" }
+  options = { drop_old_table: false, max_load: 'Threads_running=60' }
+
+  percona_alter_table :users, commands, options: options
+end
+```
+
 ## Contributing
 
 1. Fork it ( https://github.com/[my-github-username]/percona-migrations/fork )

--- a/lib/percona_migrations.rb
+++ b/lib/percona_migrations.rb
@@ -53,12 +53,10 @@ module PerconaMigrations
     end
   end
 
-  def pt_schema_tool_args
-
+  def pt_schema_tool_args(options: {})
     @config.members.map do |key|
-
+      val = options.key?(key) ? options[key] : config[key]
       arg = key.to_s.gsub(/_/,'-')
-      val = @config[key]
 
       case val
       when nil

--- a/lib/percona_migrations/runners/base.rb
+++ b/lib/percona_migrations/runners/base.rb
@@ -5,9 +5,10 @@ module PerconaMigrations
         true
       end
 
-      def initialize(table_name, commands)
+      def initialize(table_name, commands, options: {})
         @table_name = table_name
         @commands = commands
+        @options = options
       end
 
       def run

--- a/lib/percona_migrations/runners/percona.rb
+++ b/lib/percona_migrations/runners/percona.rb
@@ -12,8 +12,8 @@ module PerconaMigrations
       end
 
       def run
-        options = [
-          PerconaMigrations.pt_schema_tool_args,
+        params = [
+          PerconaMigrations.pt_schema_tool_args(options: @options),
           "--alter '#{@commands.join(', ')}'",
           "-h #{database_config['host']}",
           "-P #{database_config['port']}",
@@ -23,10 +23,10 @@ module PerconaMigrations
 
         password = database_config['password']
         if password && !password.empty?
-          options << "-p $PASSWORD"
+          params << "-p $PASSWORD"
         end
 
-        run_command(options.reject(&:empty?).join(' '), { 'PASSWORD' => password })
+        run_command(params.reject(&:empty?).join(' '), { 'PASSWORD' => password })
       end
 
       private
@@ -35,9 +35,9 @@ module PerconaMigrations
         PerconaMigrations.database_config
       end
 
-      def run_command(options, env_vars = {})
+      def run_command(params, env_vars = {})
         %w(dry-run execute).each do |mode|
-          cmd = "#{self.class.percona_command} #{options} --#{mode}"
+          cmd = "#{self.class.percona_command} #{params} --#{mode}"
 
           log "Running percona command: \"#{cmd}\""
 

--- a/lib/percona_migrations/version.rb
+++ b/lib/percona_migrations/version.rb
@@ -1,3 +1,3 @@
 module PerconaMigrations
-  VERSION = "0.0.4"
+  VERSION = "0.0.5"
 end

--- a/spec/lib/percona_migrations_spec.rb
+++ b/spec/lib/percona_migrations_spec.rb
@@ -70,4 +70,21 @@ RSpec.describe PerconaMigrations do
       end
     end
   end
+
+  describe '::pt_schema_tool_args' do
+    before do
+      subject.instance_eval { @config = @config.class.new }
+      subject.config do |c|
+        c.statistics = true
+        c.drop_old_table = false
+      end
+    end
+
+    it 'returns arguments, overriding any conflicting config settings' do
+      options = { drop_old_table: true, drop_new_table: false }
+      expect(subject.pt_schema_tool_args(options: options)).to eq(
+        '--no-drop-new-table --drop-old-table --statistics'
+      )
+    end
+  end
 end


### PR DESCRIPTION
### Problem
We want to be able to occasionally pass one-time config changes to Percona's migrations without having to change the config in the initializer

### Solution
Implement an extra argument to `percona_alter_table` that can take the options as a hash

### Notes
* After discussion amongst our team it was decided that the options hash should take precedence over the initializer config. In the event of conflicting options between the two, the options hash will override the config.
* I have added documentation for both the existing config implementation and the new options argument.
* I have also added a changelog detailing all changes to date.